### PR TITLE
Fix zone names and GitHub credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,9 +22,9 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		// Define DNS zones.
 		zones := []gcp.Zone{
-			gcp.NewZone(ZoneNicklasfrahm, "nicklasfrahm.xyz", "Nicklas Frahm's personal domain"),
-			gcp.NewZone(ZoneIntric, "intric.dk", "Intric Denmark startup"),
-			gcp.NewZone(ZoneMykilio, "mykil.io", "Mykilio project"),
+			gcp.NewZone(ZoneNicklasfrahm, "nicklasfrahm.xyz.", "Nicklas Frahm's personal domain"),
+			gcp.NewZone(ZoneIntric, "intric.dk.", "Intric Denmark startup"),
+			gcp.NewZone(ZoneMykilio, "mykil.io.", "Mykilio project"),
 		}
 
 		// Define GitHub organizations and repositories.

--- a/pkg/github/organization.go
+++ b/pkg/github/organization.go
@@ -28,10 +28,14 @@ func NewOrganizationConfig(name string, repos []Repository) *OrganizationConfig 
 }
 
 func NewOrganization(ctx *pulumi.Context, name string) (*Organization, error) {
+	// DEBUG: PAT value
+	pat := os.Getenv("PERSONAL_ACCESS_TOKEN")
+	fmt.Println(len(pat))
+
 	id := fmt.Sprintf("github-%s", name)
 	provider, err := github.NewProvider(ctx, id, &github.ProviderArgs{
 		Owner: pulumi.StringPtr(name),
-		Token: pulumi.StringPtr(os.Getenv("PERSONAL_ACCESS_TOKEN")),
+		Token: pulumi.StringPtr(pat),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/github/organization.go
+++ b/pkg/github/organization.go
@@ -28,14 +28,10 @@ func NewOrganizationConfig(name string, repos []Repository) *OrganizationConfig 
 }
 
 func NewOrganization(ctx *pulumi.Context, name string) (*Organization, error) {
-	// DEBUG: PAT value
-	pat := os.Getenv("PERSONAL_ACCESS_TOKEN")
-	fmt.Println(len(pat))
-
 	id := fmt.Sprintf("github-%s", name)
 	provider, err := github.NewProvider(ctx, id, &github.ProviderArgs{
 		Owner: pulumi.StringPtr(name),
-		Token: pulumi.StringPtr(pat),
+		Token: pulumi.StringPtr(os.Getenv("PERSONAL_ACCESS_TOKEN")),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The DNS zone names have to end with a dot (`.`). Additionally the GitHub personal access token is not recognized.