### PR TITLE
feat(pulumi): allow configuration of GitHub pages via record type

### DIFF
--- a/deploy/dns.yaml
+++ b/deploy/dns.yaml
@@ -1,9 +1,20 @@
 zones:
   - provider: cloudflare
     name: nicklasfrahm.dev
+    records:
+      - name: "@"
+        type: GITHUB_PAGES
+        githubPages:
+          org: nicklasfrahm
+      - name: kubestack
+        type: GITHUB_PAGES
+        githubPages:
+          org: nicklasfrahm
 
   - provider: cloudflare
     name: odance.dk
+    records: []
 
   - provider: cloudflare
     name: odance.nl
+    records: []

--- a/pkg/pulumi/dns/github_pages.go
+++ b/pkg/pulumi/dns/github_pages.go
@@ -1,0 +1,88 @@
+package dns
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-cloudflare/sdk/v5/go/cloudflare"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	// GithubPagesComponentType is the ID of the component type.
+	GithubPagesComponentType = "nicklasfrahm:dns:GithubPages"
+)
+
+var (
+	// githubPagesIPs contains the IPv4 address of the Github pages servers.
+	githubPagesIPs = []string{
+		"185.199.108.153",
+		"185.199.109.153",
+		"185.199.110.153",
+		"185.199.111.153",
+	}
+)
+
+// GithubPages creates DNS records for a Github pages site.
+type GithubPages struct {
+	pulumi.ResourceState
+}
+
+// NewGithubPages configures DNS for a Github pages site.
+func NewGithubPages(ctx *pulumi.Context, name string, zone *cloudflare.Zone, args *RecordSpec, opts ...pulumi.ResourceOption) (*GithubPages, error) {
+	component := &GithubPages{}
+	if err := ctx.RegisterComponentResource(GithubPagesComponentType, name, component, opts...); err != nil {
+		return nil, err
+	}
+
+	if args.GithubPages.Org == "" {
+		return nil, fmt.Errorf("%s: failed to find required argument: org", GithubPagesComponentType)
+	}
+	githubPagesSite := fmt.Sprintf("%s.github.io", args.GithubPages.Org)
+	isApex := args.Name == "@"
+
+	// Create www record.
+	wwwName := fmt.Sprintf("www.%s", args.Name)
+	if isApex {
+		wwwName = "www"
+	}
+	_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-www", name), &cloudflare.RecordArgs{
+		ZoneId: zone.ID(),
+		Name:   pulumi.String(wwwName),
+		Type:   pulumi.String("CNAME"),
+		Value:  pulumi.String(githubPagesSite),
+	}, pulumi.Parent(component))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create A records for an apex domain or a CNAME record for a subdomain.
+	if isApex {
+		for _, ip := range githubPagesIPs {
+			_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-%s", name, ip), &cloudflare.RecordArgs{
+				ZoneId: zone.ID(),
+				Name:   pulumi.String(args.Name),
+				Type:   pulumi.String("A"),
+				Value:  pulumi.String(ip),
+			}, pulumi.Parent(component))
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-cname", name), &cloudflare.RecordArgs{
+			ZoneId: zone.ID(),
+			Name:   pulumi.String(args.Name),
+			Type:   pulumi.String("CNAME"),
+			Value:  pulumi.String(githubPagesSite),
+		}, pulumi.Parent(component))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := ctx.RegisterResourceOutputs(component, pulumi.Map{}); err != nil {
+		return nil, err
+	}
+
+	return component, nil
+}

--- a/pkg/pulumi/dns/types.go
+++ b/pkg/pulumi/dns/types.go
@@ -1,13 +1,26 @@
 package dns
 
+const (
+	// RecordTypeGithubPages is the type of a GitHub Pages DNS record.
+	RecordTypeGithubPages = "GITHUB_PAGES"
+)
+
+// GitHubPagesRecordSpec is a data structure that describes a GitHub Pages DNS record.
+type GitHubPagesRecordSpec struct {
+	// Org is the name of the GitHub organization or user that owns the repository.
+	Org string `yaml:"org"`
+}
+
 // RecordSpec is a data structure that describes a DNS record.
 type RecordSpec struct {
 	// Name is the name of the DNS record.
-	Name string `yaml:"name"`
+	Name string `yaml:"name" validate:"required"`
 	// Type is the type of the DNS record.
-	Type string `yaml:"type"`
+	Type string `yaml:"type" validate:"required,oneof=GITHUB_PAGES"`
 	// Values is a list of values for the DNS record.
 	Values []string `yaml:"values"`
+	// GithubPages is configures the GitHub pages site.
+	GithubPages GitHubPagesRecordSpec `yaml:"githubPages"`
 }
 
 // ZoneSpec is a data structure that describes a DNS zone.
@@ -18,6 +31,8 @@ type ZoneSpec struct {
 	Name string `yaml:"name" validate:"required"`
 	// ID is unique identifier of the DNS zone.
 	ID string `yaml:"id"`
+	// Records is a list of DNS records.
+	Records []RecordSpec `yaml:"records" validate:"required,dive,required"`
 }
 
 // Spec is a data structure that describes the DNS configuration.

--- a/pkg/pulumi/dns/zone.go
+++ b/pkg/pulumi/dns/zone.go
@@ -42,9 +42,7 @@ func NewZone(ctx *pulumi.Context, name string, args *ZoneSpec, opts ...pulumi.Re
 		if err != nil {
 			return nil, err
 		}
-		_ = provider
 
-		// TODO: Create or import the DNS zone.
 		zoneOptions := []pulumi.ResourceOption{pulumi.Parent(provider), pulumi.Provider(provider)}
 		if args.ID != "" {
 			zoneOptions = append(zoneOptions, pulumi.Import(pulumi.ID(args.ID)))
@@ -58,6 +56,10 @@ func NewZone(ctx *pulumi.Context, name string, args *ZoneSpec, opts ...pulumi.Re
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if err := ctx.RegisterResourceOutputs(component, pulumi.Map{}); err != nil {
+		return nil, err
 	}
 
 	return component, nil


### PR DESCRIPTION
This adds an abstraction for all DNS record types and the a high-level record type for GitHub pages.