### PR TITLE
feat(dns): allow creation of DNS for physical location

### DIFF
--- a/deploy/dns.yaml
+++ b/deploy/dns.yaml
@@ -10,6 +10,30 @@ zones:
         type: GITHUB_PAGES
         githubPages:
           org: nicklasfrahm
+      - name: dktil01
+        type: SITE
+        site:
+          router: alfa.nicklasfrahm.dev
+      - name: deflf01
+        type: SITE
+        site:
+          router: bravo.nicklasfrahm.dev
+      - name: deflf02
+        type: SITE
+        site:
+          router: charlie.nicklasfrahm.dev
+      - name: dksjb00
+        type: SITE
+        site:
+          router: delta.nicklasfrahm.dev
+      - name: dksjb01
+        type: SITE
+        site:
+          router: delta.nicklasfrahm.dev
+      - name: dksjb02
+        type: SITE
+        site:
+          router: delta.nicklasfrahm.dev
 
   - provider: cloudflare
     name: odance.dk

--- a/pkg/pulumi/dns/site.go
+++ b/pkg/pulumi/dns/site.go
@@ -1,0 +1,56 @@
+package dns
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-cloudflare/sdk/v5/go/cloudflare"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	// SiteComponentType is the ID of the component type.
+	SiteComponentType = "nicklasfrahm:dns:Site"
+)
+
+// GithubPages creates DNS records for a Github pages site.
+type Site struct {
+	pulumi.ResourceState
+}
+
+// NewSite configures DNS for a Github pages site.
+func NewSite(ctx *pulumi.Context, name string, zone *cloudflare.Zone, args *RecordSpec, opts ...pulumi.ResourceOption) (*Site, error) {
+	component := &Site{}
+	if err := ctx.RegisterComponentResource(SiteComponentType, name, component, opts...); err != nil {
+		return nil, err
+	}
+
+	if args.Site.Router == "" {
+		return nil, fmt.Errorf("%s: failed to find required argument: router", SiteComponentType)
+	}
+
+	_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-base", name), &cloudflare.RecordArgs{
+		ZoneId: zone.ID(),
+		Name:   pulumi.String(args.Name),
+		Type:   pulumi.String("CNAME"),
+		Value:  pulumi.String(args.Site.Router),
+	}, pulumi.Parent(component))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-wildcard", name), &cloudflare.RecordArgs{
+		ZoneId: zone.ID(),
+		Name:   pulumi.Sprintf("*.%s", args.Name),
+		Type:   pulumi.String("CNAME"),
+		Value:  pulumi.String(args.Site.Router),
+	}, pulumi.Parent(component))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ctx.RegisterResourceOutputs(component, pulumi.Map{}); err != nil {
+		return nil, err
+	}
+
+	return component, nil
+}

--- a/pkg/pulumi/dns/site.go
+++ b/pkg/pulumi/dns/site.go
@@ -12,12 +12,12 @@ const (
 	SiteComponentType = "nicklasfrahm:dns:Site"
 )
 
-// GithubPages creates DNS records for a Github pages site.
+// Site is a set of DNS records for a physical site.
 type Site struct {
 	pulumi.ResourceState
 }
 
-// NewSite configures DNS for a Github pages site.
+// NewSite configures DNS for a physical site.
 func NewSite(ctx *pulumi.Context, name string, zone *cloudflare.Zone, args *RecordSpec, opts ...pulumi.ResourceOption) (*Site, error) {
 	component := &Site{}
 	if err := ctx.RegisterComponentResource(SiteComponentType, name, component, opts...); err != nil {

--- a/pkg/pulumi/dns/types.go
+++ b/pkg/pulumi/dns/types.go
@@ -3,6 +3,8 @@ package dns
 const (
 	// RecordTypeGithubPages is the type of a GitHub Pages DNS record.
 	RecordTypeGithubPages = "GITHUB_PAGES"
+	// RecordTypeSite is the type of a DNS record for a site.
+	RecordTypeSite = "SITE"
 )
 
 // GitHubPagesRecordSpec is a data structure that describes a GitHub Pages DNS record.
@@ -11,16 +13,24 @@ type GitHubPagesRecordSpec struct {
 	Org string `yaml:"org"`
 }
 
+// SiteRecordSpec is a data structure that describes a DNS record for a site.
+type SiteRecordSpec struct {
+	// Router is the FQDN of the edge router.
+	Router string `yaml:"router"`
+}
+
 // RecordSpec is a data structure that describes a DNS record.
 type RecordSpec struct {
 	// Name is the name of the DNS record.
 	Name string `yaml:"name" validate:"required"`
 	// Type is the type of the DNS record.
-	Type string `yaml:"type" validate:"required,oneof=GITHUB_PAGES"`
+	Type string `yaml:"type" validate:"required,oneof=GITHUB_PAGES SITE"`
 	// Values is a list of values for the DNS record.
 	Values []string `yaml:"values"`
 	// GithubPages is configures the GitHub pages site.
 	GithubPages GitHubPagesRecordSpec `yaml:"githubPages"`
+	// Site configures a site DNS record.
+	Site SiteRecordSpec `yaml:"site"`
 }
 
 // ZoneSpec is a data structure that describes a DNS zone.

--- a/pkg/pulumi/dns/zone.go
+++ b/pkg/pulumi/dns/zone.go
@@ -63,6 +63,8 @@ func NewZone(ctx *pulumi.Context, name string, args *ZoneSpec, opts ...pulumi.Re
 			switch record.Type {
 			case RecordTypeGithubPages:
 				_, err = NewGithubPages(ctx, fmt.Sprintf("%s-c.githubpages-%s", name, record.Name), zone, record, pulumi.Parent(component))
+			case RecordTypeSite:
+				_, err = NewSite(ctx, fmt.Sprintf("%s-c.site-%s", name, record.Name), zone, record, pulumi.Parent(component))
 			}
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This allows the creation of a DNS record with the type `SITE`. If the zone is `example.com`, the router is `router.example.com` and the name of the record is `site`, then the following records will be created:
- `site.example.com CNAME router.example.com`
- `*.site.example.com CNAME router.example.com`