### PR TITLE
refactor(k3se): use router FQDNs for edge management clusters

### DIFF
--- a/deploy/k3se/deflf01.yaml
+++ b/deploy/k3se/deflf01.yaml
@@ -10,7 +10,7 @@ cluster:
     # It is highly recommended to always specify this option as it
     # is used to determine the server URL of the cluster.
     tls-san:
-      - deflf01.nicklasfrahm.dev
+      - bravo.nicklasfrahm.dev
     https-listen-port: 7443
     disable:
       - traefik
@@ -34,6 +34,6 @@ nodes:
 # An SSH proxy, also known as jumpbox or a bastion host
 # can be used to access nodes in a private network.
 ssh-proxy:
-  host: deflf01.nicklasfrahm.dev
+  host: bravo.nicklasfrahm.dev
   user: nicklasfrahm
   key-file: ~/.ssh/id_ed25519

--- a/deploy/k3se/deflf02.yaml
+++ b/deploy/k3se/deflf02.yaml
@@ -10,7 +10,7 @@ cluster:
     # It is highly recommended to always specify this option as it
     # is used to determine the server URL of the cluster.
     tls-san:
-      - deflf02.nicklasfrahm.dev
+      - charlie.nicklasfrahm.dev
     https-listen-port: 7443
     disable:
       - traefik
@@ -34,6 +34,6 @@ nodes:
 # An SSH proxy, also known as jumpbox or a bastion host
 # can be used to access nodes in a private network.
 ssh-proxy:
-  host: deflf02.nicklasfrahm.dev
+  host: charlie.nicklasfrahm.dev
   user: nicklasfrahm
   key-file: ~/.ssh/id_ed25519

--- a/deploy/k3se/dksjb00.yaml
+++ b/deploy/k3se/dksjb00.yaml
@@ -10,7 +10,7 @@ cluster:
     # It is highly recommended to always specify this option as it
     # is used to determine the server URL of the cluster.
     tls-san:
-      - dksjb00.nicklasfrahm.dev
+      - delta.nicklasfrahm.dev
     https-listen-port: 7443
     disable:
       - traefik
@@ -34,6 +34,6 @@ nodes:
 # An SSH proxy, also known as jumpbox or a bastion host
 # can be used to access nodes in a private network.
 ssh-proxy:
-  host: dksjb00.nicklasfrahm.dev
+  host: delta.nicklasfrahm.dev
   user: nicklasfrahm
   key-file: ~/.ssh/id_ed25519

--- a/deploy/k3se/dktil01.yaml
+++ b/deploy/k3se/dktil01.yaml
@@ -10,7 +10,7 @@ cluster:
     # It is highly recommended to always specify this option as it
     # is used to determine the server URL of the cluster.
     tls-san:
-      - dktil01.nicklasfrahm.dev
+      - alfa.nicklasfrahm.dev
     https-listen-port: 7443
     disable:
       - traefik
@@ -34,6 +34,6 @@ nodes:
 # An SSH proxy, also known as jumpbox or a bastion host
 # can be used to access nodes in a private network.
 ssh-proxy:
-  host: dktil01.nicklasfrahm.dev
+  host: alfa.nicklasfrahm.dev
   user: nicklasfrahm
   key-file: ~/.ssh/id_ed25519


### PR DESCRIPTION
This refactors the `k3se` configuration for my single node edge clusters that will manage my routers. The incentive is to simplify the setup and reduce the dependency on a working DNS implementation. With this improvement only the router DNS record is needed to bootstrap a new site. Previously also the **site DNS records** were needed.