### PR TITLE
refactor(k3se): use loopback IPs for edge router clusters

### DIFF
--- a/deploy/k3se/deflf01.yaml
+++ b/deploy/k3se/deflf01.yaml
@@ -26,7 +26,7 @@ cluster:
 nodes:
   - role: server
     ssh:
-      host: 172.16.1.254
+      host: 172.31.255.1
       fingerprint: SHA256:spzDFMfWouRnCLwn3Ls1yufKkaI+TXXGisUnJSrBJ2U
       user: nicklasfrahm
       key-file: ~/.ssh/id_ed25519

--- a/deploy/k3se/deflf02.yaml
+++ b/deploy/k3se/deflf02.yaml
@@ -26,7 +26,7 @@ cluster:
 nodes:
   - role: server
     ssh:
-      host: 172.16.2.254
+      host: 172.31.255.2
       fingerprint: SHA256:WAr97FCNzddDuX47XhvgkmoFmEMXel/FBgK4P2sOZaE
       user: nicklasfrahm
       key-file: ~/.ssh/id_ed25519

--- a/deploy/k3se/dksjb00.yaml
+++ b/deploy/k3se/dksjb00.yaml
@@ -26,7 +26,7 @@ cluster:
 nodes:
   - role: server
     ssh:
-      host: 172.16.3.254
+      host: 172.31.255.3
       fingerprint: SHA256:g6n75j5ZwvNGVaaQlPVotH0PRoKnIx/Iaz3DGpj6ETQ
       user: nicklasfrahm
       key-file: ~/.ssh/id_ed25519


### PR DESCRIPTION
This further decouples the configuration of the router from the configuration of the cluster. It removes the requirement that there is a specific configuration on `br0` for the DMZ.