### PR TITLE
feat(dns): configure CNAME spec

### DIFF
--- a/deploy/dns.yaml
+++ b/deploy/dns.yaml
@@ -2,6 +2,10 @@ zones:
   - provider: cloudflare
     name: nicklasfrahm.dev
     records:
+      - name: gitops
+        type: CNAME
+        values:
+          - alfa.nicklasfrahm.dev
       - name: "@"
         type: GITHUB_PAGES
         githubPages:

--- a/pkg/pulumi/dns/cname.go
+++ b/pkg/pulumi/dns/cname.go
@@ -1,0 +1,48 @@
+package dns
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-cloudflare/sdk/v5/go/cloudflare"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	// CNAMEComponentType is the ID of the component type.
+	CNAMEComponentType = "nicklasfrahm:dns:CNAME"
+)
+
+// CNAME creates CNAME DNS records for the given hostname.
+type CNAME struct {
+	pulumi.ResourceState
+}
+
+// NewCNAME configures CNAME DNS records for the given hostname.
+func NewCNAME(ctx *pulumi.Context, name string, zone *cloudflare.Zone, args *RecordSpec, opts ...pulumi.ResourceOption) (*CNAME, error) {
+	component := &CNAME{}
+	if err := ctx.RegisterComponentResource(CNAMEComponentType, name, component, opts...); err != nil {
+		return nil, err
+	}
+
+	if len(args.Values) == 0 {
+		return nil, fmt.Errorf("%s: failed to find required argument: values", CNAMEComponentType)
+	}
+
+	for _, value := range args.Values {
+		_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-%s", name, value), &cloudflare.RecordArgs{
+			ZoneId: zone.ID(),
+			Name:   pulumi.String(args.Name),
+			Type:   pulumi.String("CNAME"),
+			Value:  pulumi.String(value),
+		}, pulumi.Parent(component))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := ctx.RegisterResourceOutputs(component, pulumi.Map{}); err != nil {
+		return nil, err
+	}
+
+	return component, nil
+}

--- a/pkg/pulumi/dns/types.go
+++ b/pkg/pulumi/dns/types.go
@@ -5,6 +5,8 @@ const (
 	RecordTypeGithubPages = "GITHUB_PAGES"
 	// RecordTypeSite is the type of a DNS record for a site.
 	RecordTypeSite = "SITE"
+	// RecordTypeCNAME is the type of a CNAME DNS record.
+	RecordTypeCNAME = "CNAME"
 )
 
 // GitHubPagesRecordSpec is a data structure that describes a GitHub Pages DNS record.
@@ -24,7 +26,7 @@ type RecordSpec struct {
 	// Name is the name of the DNS record.
 	Name string `yaml:"name" validate:"required"`
 	// Type is the type of the DNS record.
-	Type string `yaml:"type" validate:"required,oneof=GITHUB_PAGES SITE"`
+	Type string `yaml:"type" validate:"required,oneof=GITHUB_PAGES SITE CNAME"`
 	// Values is a list of values for the DNS record.
 	Values []string `yaml:"values"`
 	// GithubPages is configures the GitHub pages site.

--- a/pkg/pulumi/dns/zone.go
+++ b/pkg/pulumi/dns/zone.go
@@ -65,6 +65,8 @@ func NewZone(ctx *pulumi.Context, name string, args *ZoneSpec, opts ...pulumi.Re
 				_, err = NewGithubPages(ctx, fmt.Sprintf("%s-c.githubpages-%s", name, record.Name), zone, record, pulumi.Parent(component))
 			case RecordTypeSite:
 				_, err = NewSite(ctx, fmt.Sprintf("%s-c.site-%s", name, record.Name), zone, record, pulumi.Parent(component))
+			case RecordTypeCNAME:
+				_, err = NewCNAME(ctx, fmt.Sprintf("%s-c.cname-%s", name, record.Name), zone, record, pulumi.Parent(component))
 			}
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This allows the configuration of `CNAME` records using the `deploy/dns.yaml` file.