### PR TITLE
feat(dns): route HTTP traffic using traefik

### DIFF
--- a/deploy/dns.yaml
+++ b/deploy/dns.yaml
@@ -45,7 +45,7 @@ zones:
       - name: moos
         type: SITE
         site:
-          router: delta.nicklasfrahm.dev
+          router: alfa.nicklasfrahm.dev
 
   - provider: cloudflare
     name: odance.nl

--- a/deploy/kubectl/experimental/alfa-x-loadbalancing.yaml
+++ b/deploy/kubectl/experimental/alfa-x-loadbalancing.yaml
@@ -1,0 +1,58 @@
+# This configures load balancing for Kubernetes clusters hosted
+# behind the edge routers and essentially allows me to replace
+# HAProxy with Traefik to simplify configuration management.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: x-loadbalancing
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: moos-ingress
+  namespace: x-loadbalancing
+spec:
+  type: ExternalName
+  externalName: 10.3.11.103.nip.io
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  - name: https
+    port: 443
+    targetPort: 443
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: moos-ingress-http
+  namespace: x-loadbalancing
+spec:
+  entryPoints:
+    - web
+  routes:
+  - kind: Rule
+    match: HostRegexp(`moos.nicklasfrahm.dev$`)
+    priority: 10
+    services:
+    - kind: Service
+      name: moos-ingress
+      namespace: x-loadbalancing
+      port: 80
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: moos-ingress-https
+  namespace: x-loadbalancing
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: HostSNIRegexp(`moos.nicklasfrahm.dev$`)
+    priority: 10
+    services:
+    - name: moos-ingress
+      namespace: x-loadbalancing
+      port: 443


### PR DESCRIPTION
This may slightly increase latency but may in the future allow me to replace HAProxy entirely with `traefik` to simplify the load balancing setup.