### PR TITLE
fix(dns): use HAProxy until k8s API is proxied too

### DIFF
--- a/deploy/dns.yaml
+++ b/deploy/dns.yaml
@@ -45,7 +45,7 @@ zones:
       - name: moos
         type: SITE
         site:
-          router: alfa.nicklasfrahm.dev
+          router: delta.nicklasfrahm.dev
 
   - provider: cloudflare
     name: odance.nl

--- a/deploy/kubectl/experimental/alfa-x-loadbalancing.yaml
+++ b/deploy/kubectl/experimental/alfa-x-loadbalancing.yaml
@@ -13,8 +13,8 @@ metadata:
   name: moos-ingress
   namespace: x-loadbalancing
 spec:
-  type: ExternalName
-  externalName: 10.3.11.103.nip.io
+  type: ClusterIP
+  clusterIP: None
   ports:
   - name: http
     port: 80
@@ -22,6 +22,20 @@ spec:
   - name: https
     port: 443
     targetPort: 443
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: moos-ingress
+  namespace: x-loadbalancing
+subsets:
+- addresses:
+  - ip: 10.3.11.103
+  ports:
+  - name: http
+    port: 80
+  - name: https
+    port: 443
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -45,7 +59,6 @@ apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: moos-ingress-https
-  namespace: x-loadbalancing
 spec:
   entryPoints:
     - websecure
@@ -54,5 +67,6 @@ spec:
     priority: 10
     services:
     - name: moos-ingress
-      namespace: x-loadbalancing
       port: 443
+  tls:
+    passthrough: true


### PR DESCRIPTION
We also need to proxy the k8s API server traffic using `traefik` before we can use the new setup. Until then we need to use the previous HAProxy setup.