### PR TITLE
feat(k8s): create PoC for k3s in k8s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ secret*.yaml
 
 # Built binary files.
 bin/
+
+# Ignore kubeconfig files.
+kubeconfig*.yaml

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,16 @@ docker:
 	  --build-arg TARGET=$(TARGET) \
 	  --build-arg VERSION=$(VERSION) \
 	  -f build/package/Dockerfile .
+
+.PHONY: inception-up
+inception-up:
+	kubectl -n inception apply -f configs/inception/inception.yaml
+	kubectl -n inception wait --for=condition=Ready pod -l app.kubernetes.io/name=k3s-poc
+	kubectl -n inception get pods -l app.kubernetes.io/name=k3s-poc -o jsonpath='{.items[0].metadata.name}'
+	kubectl -n inception cp $$(kubectl -n inception get pods -l app.kubernetes.io/name=k3s-poc -o jsonpath='{.items[0].metadata.name}'):/etc/rancher/k3s/k3s.yaml kubeconfig.yaml
+	sed -i "s/127.0.0.1/k3s-poc.moos.nicklasfrahm.dev/" kubeconfig.yaml
+
+.PHONY: inception-down
+inception-down:
+	rm kubeconfig.yaml || true
+	kubectl delete -f configs/inception/inception.yaml

--- a/configs/inception/inception.yaml
+++ b/configs/inception/inception.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: inception
+  labels:
+    app.kubernetes.io/name: k3s-poc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k3s-poc
+  namespace: inception
+  labels:
+    app.kubernetes.io/name: k3s-poc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k3s-poc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: k3s-poc
+    spec:
+      containers:
+        - name: k3s
+          image: rancher/k3s:v1.28.2-k3s1
+          command:
+             - /bin/sh
+          args:
+            - -c
+            - |
+              /bin/k3s server \
+                --disable-agent \
+                --tls-san k3s-poc.moos.nicklasfrahm.dev \
+                --https-listen-port 443 \
+                && true
+          imagePullPolicy: Always
+          ports:
+            - name: https
+              containerPort: 443
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 1000Mi
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: k3s-poc
+  namespace: inception
+  labels:
+    app.kubernetes.io/name: k3s-poc
+spec:
+  type: ClusterIP
+  ports:
+    - name: https
+      port: 443
+      targetPort: 443
+  selector:
+    app.kubernetes.io/name: k3s-poc
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: k3s-poc
+  namespace: inception
+  labels:
+    app.kubernetes.io/name: k3s-poc
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: HostSNI(`k3s-poc.moos.nicklasfrahm.dev`)
+    services:
+    - name: k3s-poc
+      port: 443
+  tls:
+    passthrough: true


### PR DESCRIPTION
This adds a very simple PoC to run a `k3s` server in another cluster as a **managed controlplane**. Open TODOs are:
* Further testing by adding agents as all pods are currently `Pending`.
* Adding a volume to persist the state of the `k3s` server.
* HA using `etcd`.