### PR TITLE
feat(config): deploy new single node cluster

### DIFF
--- a/deploy/dns.yaml
+++ b/deploy/dns.yaml
@@ -22,23 +22,7 @@ zones:
         type: GITHUB_PAGES
         githubPages:
           org: nicklasfrahm
-      - name: dktil01
-        type: SITE
-        site:
-          router: alfa.nicklasfrahm.dev
-      - name: deflf01
-        type: SITE
-        site:
-          router: bravo.nicklasfrahm.dev
-      - name: deflf02
-        type: SITE
-        site:
-          router: charlie.nicklasfrahm.dev
-      - name: dksjb00
-        type: SITE
-        site:
-          router: delta.nicklasfrahm.dev
-      - name: dksjb02
+      - name: november
         type: SITE
         site:
           router: delta.nicklasfrahm.dev

--- a/deploy/k3se/november.yaml
+++ b/deploy/k3se/november.yaml
@@ -10,11 +10,11 @@ cluster:
     # It is highly recommended to always specify this option as it
     # is used to determine the server URL of the cluster.
     tls-san:
-      - 172.16.0.241
-    https-listen-port: 7443
+      - november.nicklasfrahm.dev
+    https-listen-port: 6443
     disable:
       - traefik
-    flannel-iface: eth0
+    flannel-iface: enp1s0
     cluster-cidr:
       - 10.254.0.0/16
     service-cidr:
@@ -27,13 +27,13 @@ nodes:
   - role: server
     ssh:
       host: 172.16.0.241
-      fingerprint: SHA256:LWV+uwVmsbFFg8ebhCm+U8QnFPZakh1ENqCTGlYgHlI
+      fingerprint: SHA256:F2RZFjxyQuDQqdnv8nIC85oJru6//C9bQGwqgDE1n4w
       user: nicklasfrahm
       key-file: ~/.ssh/id_ed25519
 
 # An SSH proxy, also known as jumpbox or a bastion host
 # can be used to access nodes in a private network.
 ssh-proxy:
-  host: dktil01.nicklasfrahm.dev
+  host: delta.nicklasfrahm.dev
   user: nicklasfrahm
   key-file: ~/.ssh/id_ed25519


### PR DESCRIPTION
This creates a single node cluster on `november` (Rock Pi X) for experiments using nested `k3s` and Kubernetes dashboard.