### PR TITLE
feat(tools): add docker push target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,7 @@ docker:
 	  --build-arg TARGET=$(TARGET) \
 	  --build-arg VERSION=$(VERSION) \
 	  -f build/package/Dockerfile .
+
+.PHONY: docker-push
+docker-push: docker
+	docker push $(REGISTRY)/$(REPO)-$(TARGET):latest


### PR DESCRIPTION
This adds a target to simplify the publication of the container image while I am to lazy to set up a CD workflow.