### PR TITLE
fix(pulumi): avoid incorrect resource URN

### DIFF
--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Preview infrastructure
         uses: pulumi/actions@v4
-
         with:
           comment-on-pr: true
           command: preview

--- a/charts/edge/values.yaml
+++ b/charts/edge/values.yaml
@@ -35,7 +35,7 @@ services:
         host: 10.3.11.103.nip.io
 
     - name: zebra
-      host: zebra.nicklasfrahm.dev
+      host: k8s.zebra.nicklasfrahm.dev
       backend:
         host: zebra.srv.nicklasfrahm.dev
         port: 6443

--- a/charts/edge/values.yaml
+++ b/charts/edge/values.yaml
@@ -3,38 +3,38 @@ fullnameOverride: ""
 
 services:
   http:
-    - name: example
+    - name: edge
       host: edge.nicklasfrahm.dev
       backend:
         host: 10.3.11.103.nip.io
 
-    - name: registry-november
+    - name: november-registry
       host: registry.november.nicklasfrahm.dev
       backend:
         host: 10.3.11.103.nip.io
 
-    - name: dashboard-november
+    - name: november-dashboard
       host: dashboard.november.nicklasfrahm.dev
       backend:
         host: 10.3.11.103.nip.io
 
   https:
-    - name: example
+    - name: edge
       host: edge.nicklasfrahm.dev
       backend:
         host: 10.3.11.103.nip.io
 
-    - name: registry-november
+    - name: november-registry
       host: registry.november.nicklasfrahm.dev
       backend:
         host: 10.3.11.103.nip.io
 
-    - name: dashboard-november
+    - name: november-dashboard
       host: dashboard.november.nicklasfrahm.dev
       backend:
         host: 10.3.11.103.nip.io
 
-    - name: zebra
+    - name: zebra-k8s
       host: k8s.zebra.nicklasfrahm.dev
       backend:
         host: zebra.srv.nicklasfrahm.dev

--- a/pkg/pulumi/dns/a.go
+++ b/pkg/pulumi/dns/a.go
@@ -20,12 +20,12 @@ type A struct {
 // NewA configures A DNS records for the given hostname.
 func NewA(ctx *pulumi.Context, name string, zone *cloudflare.Zone, args *RecordSpec, opts ...pulumi.ResourceOption) (*A, error) {
 	component := &A{}
-	if err := ctx.RegisterComponentResource(CNAMEComponentType, name, component, opts...); err != nil {
+	if err := ctx.RegisterComponentResource(AComponentType, name, component, opts...); err != nil {
 		return nil, err
 	}
 
 	if len(args.Values) == 0 {
-		return nil, fmt.Errorf("%s: failed to find required argument: values", CNAMEComponentType)
+		return nil, fmt.Errorf("%s: failed to find required argument: values", AComponentType)
 	}
 
 	for _, value := range args.Values {


### PR DESCRIPTION
This avoids using an incorrect resoure URN for the A records. Additionally it fixes TLS routing using the correct SAN.