### PR TITLE
fix(ci): prevent drift by always running refresh

### DIFF
--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Preview infrastructure
         uses: pulumi/actions@v4
         with:
+          refresh: true
           comment-on-pr: true
           command: preview
           stack-name: ${{ matrix.stack }}
@@ -76,10 +77,10 @@ jobs:
       - name: Update infrastructure
         uses: pulumi/actions@v4
         with:
+          refresh: true
           command: update
           stack-name: ${{ matrix.stack }}
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-


### PR DESCRIPTION
This will force pulumi to always perform a refresh before a preview or an update to prevent drift.