### PR TITLE
fix(helm): add kubeapi listener

### DIFF
--- a/charts/edge/templates/kubeapi.yaml
+++ b/charts/edge/templates/kubeapi.yaml
@@ -1,0 +1,34 @@
+{{- range $service := .Values.services.kubeapi }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "edge.fullname" $ }}-kubeapi-{{ $service.name }}
+  labels:
+    {{- include "edge.labels" $ | nindent 4 }}
+spec:
+  type: ExternalName
+  externalName: {{ $service.backend.host }}
+  ports:
+    - name: https
+      protocol: TCP
+      port: 6443
+      targetPort: {{ default 6443 $service.backend.port }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: {{ include "edge.fullname" $ }}-kubeapi-{{ $service.name }}
+  labels:
+    {{- include "edge.labels" $ | nindent 4 }}
+spec:
+  entryPoints:
+    - kubeapi
+  routes:
+    - match: HostSNI(`{{ $service.host }}`)
+      services:
+        - name: {{ include "edge.fullname" $ }}-kubeapi-{{ $service.name }}
+          port: 6443
+  tls:
+    passthrough: true
+{{- end }}

--- a/charts/edge/values.yaml
+++ b/charts/edge/values.yaml
@@ -34,8 +34,8 @@ services:
       backend:
         host: 10.3.11.103.nip.io
 
+  kubeapi:
     - name: zebra-k8s
       host: k8s.zebra.nicklasfrahm.dev
       backend:
         host: zebra.srv.nicklasfrahm.dev
-        port: 6443

--- a/deploy/argocd/root/templates/ingress/traefik.yaml
+++ b/deploy/argocd/root/templates/ingress/traefik.yaml
@@ -83,6 +83,13 @@ spec:
                 protocol: TCP
                 tls:
                   enabled: false
+              kubeapi:
+                port: 9443
+                expose: true
+                exposedPort: 6443
+                protocol: TCP
+                tls:
+                  enabled: false
 
             providers:
               kubernetesIngress:

--- a/deploy/k3se/zebra.yaml
+++ b/deploy/k3se/zebra.yaml
@@ -11,8 +11,6 @@ cluster:
     # is used to determine the server URL of the cluster.
     tls-san:
       - k8s.zebra.nicklasfrahm.dev
-    advertise-port: 443
-    https-listen-port: 6443
     disable:
       - traefik
     flannel-iface: enp3s0


### PR DESCRIPTION
This configuration should only apply to K8S at the network edge, but currently, it will apply to all clusters. We need to add an exception.