### PR TITLE
feat(dns): add edge router server records

### DIFF
--- a/deploy/dns.yaml
+++ b/deploy/dns.yaml
@@ -36,11 +36,27 @@ zones:
         type: SITE
         site:
           router: delta.nicklasfrahm.dev
-      # TODO: Remove this once I have an internal DNS server.
+      # TODO: Remove these once I have an internal DNS server.
       - name: zebra.srv
         type: A
         values:
           - 10.0.11.102
+      - name: alfa.srv
+        type: A
+        values:
+          - 172.31.255.0
+      - name: bravo.srv
+        type: A
+        values:
+          - 172.31.255.1
+      - name: charlie.srv
+        type: A
+        values:
+          - 172.31.255.2
+      - name: delta.srv
+        type: A
+        values:
+          - 172.31.255.3
 
   - provider: cloudflare
     name: odance.nl


### PR DESCRIPTION
This adds internal DNS records for my edge routers. I am aware that this may reveal my internal network architecture, but while I don't have internal DNS this is a reasonable workaround.