### PR TITLE
fix(pulumi): add metadata to infrastructure

### DIFF
--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -1,0 +1,22 @@
+package metadata
+
+import "encoding/json"
+
+// Manager describes which service is administering the infrastructure.
+type Manager string
+
+const (
+	// ManagerPulumi indicates that pulumi is managing the infrastructure.
+	ManagerPulumi Manager = "pulumi"
+)
+
+// Metadata is a data structure that contains metadata about a piece of infrastructure.
+type Metadata struct {
+	// Manager is the name of the service administering the infrastructure.
+	Manager Manager `json:"manager"`
+}
+
+// JSON returns the JSON representation of the metadata.
+func (m *Metadata) JSON() ([]byte, error) {
+	return json.Marshal(m)
+}

--- a/pkg/pulumi/dns/a.go
+++ b/pkg/pulumi/dns/a.go
@@ -28,12 +28,19 @@ func NewA(ctx *pulumi.Context, name string, zone *cloudflare.Zone, args *RecordS
 		return nil, fmt.Errorf("%s: failed to find required argument: values", AComponentType)
 	}
 
+	metadata, err := newMetadataString()
+	if err != nil {
+		return nil, err
+	}
+
 	for _, value := range args.Values {
+
 		_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-%s", name, value), &cloudflare.RecordArgs{
-			ZoneId: zone.ID(),
-			Name:   pulumi.String(args.Name),
-			Type:   pulumi.String("A"),
-			Value:  pulumi.String(value),
+			ZoneId:  zone.ID(),
+			Name:    pulumi.String(args.Name),
+			Type:    pulumi.String("A"),
+			Value:   pulumi.String(value),
+			Comment: pulumi.String(metadata),
 		}, pulumi.Parent(component))
 		if err != nil {
 			return nil, err

--- a/pkg/pulumi/dns/github_pages.go
+++ b/pkg/pulumi/dns/github_pages.go
@@ -40,16 +40,22 @@ func NewGithubPages(ctx *pulumi.Context, name string, zone *cloudflare.Zone, arg
 	githubPagesSite := fmt.Sprintf("%s.github.io", args.GithubPages.Org)
 	isApex := args.Name == "@"
 
+	metadata, err := newMetadataString()
+	if err != nil {
+		return nil, err
+	}
+
 	// Create www record.
 	wwwName := fmt.Sprintf("www.%s", args.Name)
 	if isApex {
 		wwwName = "www"
 	}
-	_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-www", name), &cloudflare.RecordArgs{
-		ZoneId: zone.ID(),
-		Name:   pulumi.String(wwwName),
-		Type:   pulumi.String("CNAME"),
-		Value:  pulumi.String(githubPagesSite),
+	_, err = cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-www", name), &cloudflare.RecordArgs{
+		ZoneId:  zone.ID(),
+		Name:    pulumi.String(wwwName),
+		Type:    pulumi.String("CNAME"),
+		Value:   pulumi.String(githubPagesSite),
+		Comment: pulumi.String(metadata),
 	}, pulumi.Parent(component))
 	if err != nil {
 		return nil, err
@@ -59,10 +65,11 @@ func NewGithubPages(ctx *pulumi.Context, name string, zone *cloudflare.Zone, arg
 	if isApex {
 		for _, ip := range githubPagesIPs {
 			_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-%s", name, ip), &cloudflare.RecordArgs{
-				ZoneId: zone.ID(),
-				Name:   pulumi.String(args.Name),
-				Type:   pulumi.String("A"),
-				Value:  pulumi.String(ip),
+				ZoneId:  zone.ID(),
+				Name:    pulumi.String(args.Name),
+				Type:    pulumi.String("A"),
+				Value:   pulumi.String(ip),
+				Comment: pulumi.String(metadata),
 			}, pulumi.Parent(component))
 			if err != nil {
 				return nil, err
@@ -70,10 +77,11 @@ func NewGithubPages(ctx *pulumi.Context, name string, zone *cloudflare.Zone, arg
 		}
 	} else {
 		_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-cname", name), &cloudflare.RecordArgs{
-			ZoneId: zone.ID(),
-			Name:   pulumi.String(args.Name),
-			Type:   pulumi.String("CNAME"),
-			Value:  pulumi.String(githubPagesSite),
+			ZoneId:  zone.ID(),
+			Name:    pulumi.String(args.Name),
+			Type:    pulumi.String("CNAME"),
+			Value:   pulumi.String(githubPagesSite),
+			Comment: pulumi.String(metadata),
 		}, pulumi.Parent(component))
 		if err != nil {
 			return nil, err

--- a/pkg/pulumi/dns/helpers.go
+++ b/pkg/pulumi/dns/helpers.go
@@ -1,0 +1,20 @@
+package dns
+
+import (
+	"github.com/nicklasfrahm/infrastructure/pkg/metadata"
+)
+
+// newMetadataString generates a string containing
+// metadata about the infrastructure.
+func newMetadataString() (string, error) {
+	meta := &metadata.Metadata{
+		Manager: metadata.ManagerPulumi,
+	}
+
+	metaJSON, err := meta.JSON()
+	if err != nil {
+		return "", err
+	}
+
+	return string(metaJSON), nil
+}

--- a/pkg/pulumi/dns/site.go
+++ b/pkg/pulumi/dns/site.go
@@ -28,21 +28,28 @@ func NewSite(ctx *pulumi.Context, name string, zone *cloudflare.Zone, args *Reco
 		return nil, fmt.Errorf("%s: failed to find required argument: router", SiteComponentType)
 	}
 
-	_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-base", name), &cloudflare.RecordArgs{
-		ZoneId: zone.ID(),
-		Name:   pulumi.String(args.Name),
-		Type:   pulumi.String("CNAME"),
-		Value:  pulumi.String(args.Site.Router),
+	metadata, err := newMetadataString()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-base", name), &cloudflare.RecordArgs{
+		ZoneId:  zone.ID(),
+		Name:    pulumi.String(args.Name),
+		Type:    pulumi.String("CNAME"),
+		Value:   pulumi.String(args.Site.Router),
+		Comment: pulumi.String(metadata),
 	}, pulumi.Parent(component))
 	if err != nil {
 		return nil, err
 	}
 
 	_, err = cloudflare.NewRecord(ctx, fmt.Sprintf("%s-r.record-wildcard", name), &cloudflare.RecordArgs{
-		ZoneId: zone.ID(),
-		Name:   pulumi.Sprintf("*.%s", args.Name),
-		Type:   pulumi.String("CNAME"),
-		Value:  pulumi.String(args.Site.Router),
+		ZoneId:  zone.ID(),
+		Name:    pulumi.Sprintf("*.%s", args.Name),
+		Type:    pulumi.String("CNAME"),
+		Value:   pulumi.String(args.Site.Router),
+		Comment: pulumi.String(metadata),
 	}, pulumi.Parent(component))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This adds JSON comments to all DNS records that are managed via pulumi to indicate that they are managed via pulumi.