### PR TITLE
feat(kubernetes): deploy cilium as unified network solution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ odance:
 router-up:
 	k3se up deploy/k3se/$(ROUTER).cilium.yaml
 	kubectl apply --server-side --force-conflicts -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/experimental-install.yaml
-	ROUTER=$(ROUTER) envsubst < deploy/helm/cilium.values.yaml | helm upgrade --install cilium cilium/cilium --namespace kube-system -f -
+	ROUTER=$(ROUTER) envsubst < deploy/helm/cilium.values.yaml | helm upgrade --install cilium cilium/cilium --namespace kube-system --version 1.15.0-pre.2 -f -
 	LOADBALANCER_IP=$(shell dig +short $(ROUTER).nicklasfrahm.dev) envsubst < deploy/kubectl/cilium/ciliumloadbalancerippool.yaml | kubectl apply -f -
 	kubectl apply -f deploy/kubectl/cilium/gateway.yaml
 	kubectl apply -f deploy/kubectl/api/metal.yaml

--- a/deploy/dns.yaml
+++ b/deploy/dns.yaml
@@ -36,11 +36,27 @@ zones:
         type: SITE
         site:
           router: delta.nicklasfrahm.dev
-      # TODO: Remove this once I have an internal DNS server.
+      # TODO: Remove these once I have an internal DNS server.
       - name: zebra.srv
         type: A
         values:
           - 10.0.11.102
+      - name: alfa.srv
+        type: A
+        values:
+          - 172.31.255.0
+      - name: bravo.srv
+        type: A
+        values:
+          - 172.31.255.1
+      - name: charlie.srv
+        type: A
+        values:
+          - 172.31.255.2
+      - name: delta.srv
+        type: A
+        values:
+          - 172.31.255.3
 
   - provider: cloudflare
     name: odance.nl

--- a/deploy/helm/cilium.values.yaml
+++ b/deploy/helm/cilium.values.yaml
@@ -23,12 +23,13 @@ gatewayAPI:
   # This requires the Gateway APIs to be installed prior to installing cilium.
   enabled: true
 
+# TODO: Fix this.
 # https://github.com/cilium/cilium/blob/103077d3ecf826b9329a02f7c0c0db8190452fe7/install/kubernetes/cilium/templates/cilium-configmap.yaml#L704
 # nodePort:
 #   # Prevent cilium from getting confused which interface is the WAN and which is the LAN.
 #   directRoutingDevice: lo
-
-# # Prevent the cilium-agent from being confused between the WAN and the LAN interface.
-devices:
-  - lo
-  - enp2s0
+# Prevent the cilium-agent from being confused between the WAN and the LAN interface.
+# devices:
+#   - lo
+#   - enp2s0
+# enableRuntimeDeviceDetection: true

--- a/deploy/helm/cilium.values.yaml
+++ b/deploy/helm/cilium.values.yaml
@@ -1,0 +1,28 @@
+cluster:
+  name: "${ROUTER}"
+
+operator:
+  # This is only needed when running on a single node.
+  replicas: 1
+
+kubeProxyReplacement: "true"
+
+# This is needed to allow cilium to reliably connect
+# to the Kubernetes API without hardcoding IPs.
+k8sServiceHost: "${ROUTER}.nicklasfrahm.dev"
+k8sServicePort: 7443
+
+ipam:
+  operator:
+    # This is needed to prevent cilium from picking "10.0.0.0/8"
+    # as the pod CIDR (which is an insane default).
+    clusterPoolIPv4PodCIDRList:
+      - "172.28.0.0/16"
+
+gatewayAPI:
+  # This requires the Gateway APIs to be installed prior to installing cilium.
+  enabled: true
+
+loadBalancer:
+  # This enables the L4 load balancer for anything but the Kubernetes API.
+  standalone: true

--- a/deploy/helm/cilium.values.yaml
+++ b/deploy/helm/cilium.values.yaml
@@ -23,6 +23,12 @@ gatewayAPI:
   # This requires the Gateway APIs to be installed prior to installing cilium.
   enabled: true
 
-loadBalancer:
-  # This enables the L4 load balancer for anything but the Kubernetes API.
-  standalone: true
+# https://github.com/cilium/cilium/blob/103077d3ecf826b9329a02f7c0c0db8190452fe7/install/kubernetes/cilium/templates/cilium-configmap.yaml#L704
+# nodePort:
+#   # Prevent cilium from getting confused which interface is the WAN and which is the LAN.
+#   directRoutingDevice: lo
+
+# # Prevent the cilium-agent from being confused between the WAN and the LAN interface.
+devices:
+  - lo
+  - enp2s0

--- a/deploy/k3se/alfa.cilium.yaml
+++ b/deploy/k3se/alfa.cilium.yaml
@@ -1,0 +1,44 @@
+# Version may either be a specific k3s version or a release channel
+# as listed here: https://update.k3s.io/v1-release/channels
+version: stable
+
+# Cluster provides cluster-wide settings that should be applied
+# to all nodes in the cluster. All options are equivalent to the
+# commmand line options of the `k3s` command.
+cluster:
+  server:
+    # It is highly recommended to always specify this option as it
+    # is used to determine the server URL of the cluster.
+    tls-san:
+      - alfa.nicklasfrahm.dev
+    https-listen-port: 7443
+    disable:
+      - traefik
+      - servicelb
+    node-ip:
+      - 172.31.255.0
+    disable-kube-proxy: true
+    disable-network-policy: true
+    flannel-backend: none
+    cluster-cidr:
+      - 172.28.0.0/16
+    service-cidr:
+      - 172.29.0.0/16
+    cluster-dns:
+      - 172.29.0.10
+
+# A list of all nodes in the cluster and their connection information.
+nodes:
+  - role: server
+    ssh:
+      host: 172.31.255.0
+      fingerprint: SHA256:GxNvyufD71QuCnH04eNp3LzCGuTV+ookFzVGUtlWvCI
+      user: nicklasfrahm
+      key-file: ~/.ssh/id_ed25519
+
+# An SSH proxy, also known as jumpbox or a bastion host
+# can be used to access nodes in a private network.
+ssh-proxy:
+  host: alfa.nicklasfrahm.dev
+  user: nicklasfrahm
+  key-file: ~/.ssh/id_ed25519

--- a/deploy/kubectl/api/metal.yaml
+++ b/deploy/kubectl/api/metal.yaml
@@ -53,37 +53,17 @@ spec:
       targetPort: 8080
       protocol: TCP
 ---
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
 metadata:
   name: metal-api
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
-    traefik.ingress.kubernetes.io/router.middlewares: api-metal-api@kubernetescrd
-    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
+  parentRefs:
+    - name: default
+      namespace: default
+  hostnames:
+    - "alfa.nicklasfrahm.dev"
   rules:
-    - host: api.nicklasfrahm.dev
-      http:
-        paths:
-          - path: /metal
-            pathType: Prefix
-            backend:
-              service:
-                name: metal-api
-                port:
-                  number: 80
-  tls:
-    - hosts:
-        - api.nicklasfrahm.dev
-      secretName: api.nicklasfrahm.dev
----
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: metal-api
-spec:
-  stripPrefix:
-    prefixes:
-      - /metal
+    - backendRefs:
+        - name: metal-api
+          port: 80

--- a/deploy/kubectl/cilium/ciliumloadbalancerippool.yaml
+++ b/deploy/kubectl/cilium/ciliumloadbalancerippool.yaml
@@ -1,0 +1,7 @@
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: public
+spec:
+  cidrs:
+  - cidr: "${LOADBALANCER_IP}/32"

--- a/deploy/kubectl/cilium/gateway.yaml
+++ b/deploy/kubectl/cilium/gateway.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+  - name: https
+    port: 443
+    protocol: TLS
+    tls:
+      mode: Passthrough
+  - name: kubeapi
+    port: 6443
+    protocol: TLS
+    tls:
+      mode: Passthrough

--- a/docs/ipam.md
+++ b/docs/ipam.md
@@ -33,3 +33,12 @@ This section contains the IP addresses of VPN networks.
 | Network         | Gateway        | Description                                   |
 | --------------- | -------------- | --------------------------------------------- |
 | `172.30.0.0/24` | `172.30.0.254` | Wireguard peer-to-site VPN network on `alfa`. |
+
+## Kubernetes networks
+
+The following networks are used by Kubernetes. They are NATed using the configured CNI and thus not routable.
+
+| Network         | Description                 |
+| --------------- | --------------------------- |
+| `172.28.0.0/16` | Kubernetes pod network.     |
+| `172.29.0.0/16` | Kubernetes service network. |


### PR DESCRIPTION
This deploys `cilium`. Currently the following issues need solving:
- [x] Gateway API
- [x] Gateway `LoadBalancer` remains `Pending` (workaround: use cilium `1.15.0-pre.2`)  
- [x] Can't use `CiliumLoadBalancerIPPool` with `/32` prefix (expect 1 available IP, got 0)
  ```txt
  nicklasfrahm@gl552vw:~/repos/nicklasfrahm/infrastructure$ k get ippools
  NAME     DISABLED   CONFLICTING   IPS AVAILABLE   AGE
  public   false      False         0               28m
  ```
- [ ] Traffic to externalIP gets rejected (`ERR_CONNECTION_REFUSED`, NetworkPolicy missing?)
- [ ] Verify in-cluster traffic

> So far I am not happy with the complexity of this. Possbily it may be easier to use `hostNetwork` pods with the [Envoy Gateway](https://gateway.envoyproxy.io/). I think I should not rely on `LoadBalancer` type services for ingress traffic. For internal traffic, I can do that because I have my own isolated BGP communities.