### PR TITLE
fix(config): use new DMZ IP range for delta

### DIFF
--- a/configs/armbian-build/userpatches/overlay/cloud-init/network-config
+++ b/configs/armbian-build/userpatches/overlay/cloud-init/network-config
@@ -2,6 +2,11 @@ network:
   version: 2
   renderer: networkd
   ethernets:
+    lo:
+      match:
+        name: lo
+      addresses:
+        - 172.31.255.3/32
     wan:
       dhcp4: true
       dhcp6: false

--- a/deploy/k3se/delta.yaml
+++ b/deploy/k3se/delta.yaml
@@ -16,11 +16,11 @@ cluster:
       - traefik
     flannel-iface: eth0
     cluster-cidr:
-      - 10.254.0.0/16
+      - 172.28.0.0/16
     service-cidr:
-      - 10.255.0.0/16
+      - 172.29.0.0/16
     cluster-dns:
-      - 10.255.0.10
+      - 172.29.0.10/16
 
 # A list of all nodes in the cluster and their connection information.
 nodes:

--- a/deploy/k3se/delta.yaml
+++ b/deploy/k3se/delta.yaml
@@ -14,7 +14,7 @@ cluster:
     https-listen-port: 7443
     disable:
       - traefik
-    flannel-iface: eth0
+    flannel-iface: wan
     cluster-cidr:
       - 172.28.0.0/16
     service-cidr:
@@ -27,7 +27,7 @@ nodes:
   - role: server
     ssh:
       host: 172.31.255.3
-      fingerprint: SHA256:g6n75j5ZwvNGVaaQlPVotH0PRoKnIx/Iaz3DGpj6ETQ
+      fingerprint: SHA256:lYxnP54ekc+5FBcms7KVr29KiqeSX5yfFdYMc59G81M
       user: nicklasfrahm
       key-file: ~/.ssh/id_ed25519
 

--- a/deploy/k3se/delta.yaml
+++ b/deploy/k3se/delta.yaml
@@ -20,7 +20,7 @@ cluster:
     service-cidr:
       - 172.29.0.0/16
     cluster-dns:
-      - 172.29.0.10/16
+      - 172.29.0.10
 
 # A list of all nodes in the cluster and their connection information.
 nodes:


### PR DESCRIPTION
This reconfigures `delta` to use the new IP allocations for the DMZ.