### PR TITLE
fix(config): remove unused private DNS records

### DIFF
--- a/deploy/dns.yaml
+++ b/deploy/dns.yaml
@@ -36,27 +36,6 @@ zones:
         type: SITE
         site:
           router: delta.nicklasfrahm.dev
-      # TODO: Remove these once I have an internal DNS server.
-      - name: zebra.srv
-        type: A
-        values:
-          - 10.0.11.102
-      - name: alfa.srv
-        type: A
-        values:
-          - 172.31.255.0
-      - name: bravo.srv
-        type: A
-        values:
-          - 172.31.255.1
-      - name: charlie.srv
-        type: A
-        values:
-          - 172.31.255.2
-      - name: delta.srv
-        type: A
-        values:
-          - 172.31.255.3
 
   - provider: cloudflare
     name: odance.nl


### PR DESCRIPTION
This removes the unused internal `srv.nicklasfrahm.dev` records.