### PR TITLE
feat(config): enable GitHub pages for kraut docs

### DIFF
--- a/deploy/dns.yaml
+++ b/deploy/dns.yaml
@@ -18,7 +18,7 @@ zones:
         type: GITHUB_PAGES
         githubPages:
           org: nicklasfrahm
-      - name: kubestack
+      - name: kraut
         type: GITHUB_PAGES
         githubPages:
           org: nicklasfrahm


### PR DESCRIPTION
This removes the DNS record for `kubestack` in favor of its new name `kraut`.