### PR TITLE
feat(auth): enable OIDC federation for k8s accounts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+charts/*.yaml

--- a/charts/workload-identity/Chart.yaml
+++ b/charts/workload-identity/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: workload-identity
+description: A helm chart to enable OIDC federation on a generic Kubernetes cluster.
+version: 0.1.0
+appVersion: 0.1.0

--- a/charts/workload-identity/README.md
+++ b/charts/workload-identity/README.md
@@ -1,6 +1,9 @@
 # Workload Identity
 
-This helm chart enables unauthenticated access to the OpenID discovery endpoint of the Kubernetes API server. This is required if you want to authenticate to another service using a Kubernetes service account. For reference, see the [OIDC issuer discovery section in the official Kubernetes documentation][oidc-issuer-discovery].
+This helm chart enables unauthenticated access to the OpenID discovery endpoint of the Kubernetes API server. This is required if you want to authenticate to another service using a Kubernetes service account. For more information, see the documents below:
+
+- [OIDC issuer discovery section in the official Kubernetes documentation][oidc-issuer-discovery]
+- [Service Account signing key via KEP 1393][kep-1393]
 
 ## Prerequisites
 
@@ -14,3 +17,4 @@ Additionally, it may be helpful to explicitly set the following two API server f
 - `--service-account-jwks-uri=https://k8s.example.com:6443/openid/v1/jwks`
 
 [oidc-issuer-discovery]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
+[kep-1393]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1393-oidc-discovery

--- a/charts/workload-identity/README.md
+++ b/charts/workload-identity/README.md
@@ -1,0 +1,16 @@
+# Workload Identity
+
+This helm chart enables unauthenticated access to the OpenID discovery endpoint of the Kubernetes API server. This is required if you want to authenticate to another service using a Kubernetes service account. For reference, see the [OIDC issuer discovery section in the official Kubernetes documentation][oidc-issuer-discovery].
+
+## Prerequisites
+
+- Kubernetes 1.21+
+- Kubernetes API server must be reachable from the federating OIDC provider
+- Anonymous authentication enabled via `--anonymous-auth=true` Kubernetes API server flag
+
+Additionally, it may be helpful to explicitly set the following two API server flags:
+
+- `--service-account-issuer=https://k8s.example.com:6443`
+- `--service-account-jwks-uri=https://k8s.example.com:6443/openid/v1/jwks`
+
+[oidc-issuer-discovery]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery

--- a/charts/workload-identity/templates/NOTES.txt
+++ b/charts/workload-identity/templates/NOTES.txt
@@ -1,0 +1,6 @@
+You have now enabled unauthenticated access to the OIDC discovery endpoint,
+which can be used to federate credentials to a service running inside the
+Kubernetes cluster.
+
+You may review the OIDC discovery endpoint at the following URL:
+  <api-server-url>/.well-known/openid-configuration

--- a/charts/workload-identity/templates/_helpers.tpl
+++ b/charts/workload-identity/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "workload-identity.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels. */}}
+{{- define "workload-identity.labels" -}}
+helm.sh/chart: {{ include "workload-identity.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/workload-identity/templates/clusterrolebinding.yaml
+++ b/charts/workload-identity/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: {{ .Chart.Name }}-service-account-issuer-discovery
+  labels:
+    {{- include "workload-identity.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:service-account-issuer-discovery
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:unauthenticated

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -1,0 +1,8 @@
+# Identity
+
+This document describes how identity and access management is handled.
+
+## Scenarios
+
+- **A service running as a Kubernetes workload**  
+  To support this scenario, the Kubernetes cluster must have the `charts/workload-identity` Helm chart installed. Additionally, the service must be able to obtain a service account token from the Kubernetes API server. The service account token can then be exchanged with other OpenID Connect providers to authenticate to other services.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -5,4 +5,4 @@ This document describes how identity and access management is handled.
 ## Scenarios
 
 - **A service running as a Kubernetes workload**  
-  To support this scenario, the Kubernetes cluster must have the `charts/workload-identity` Helm chart installed. Additionally, the service must be able to obtain a service account token from the Kubernetes API server. The service account token can then be exchanged with other OpenID Connect providers to authenticate to other services.
+  To support this scenario, the Kubernetes cluster must have the `charts/workload-identity` Helm chart installed. Additionally, the service must be able to obtain a service account token from the Kubernetes API server. The service account token can then be exchanged with other OpenID Connect providers to authenticate to other services. This also requires some additional Kubernetes API server flags to be set. See the [Workload Identity](../charts/workload-identity/README.md) chart documentation for more information.


### PR DESCRIPTION
This creates a tiny Helm chart that can be used to enable OIDC federation, similar to what many public cloud providers offer. 