### PR TITLE
feat(o11y): create simple centralized monitoring stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ credentials*.json
 charts/**/charts
 deploy/**/charts
 secret*.yaml
+**/Chart.lock
+**/values.*.all.yaml
 
 # Built binary files.
 bin/

--- a/deploy/helm/o11y-client/Chart.yaml
+++ b/deploy/helm/o11y-client/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: o11y-client
+description: The client-side component of an observability platform.
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+dependencies:
+  - name: victoria-metrics-k8s-stack
+    version: 0.19.4
+    repository: https://victoriametrics.github.io/helm-charts/
+    condition: victoria-metrics-k8s-stack.enabled

--- a/deploy/helm/o11y-client/README.md
+++ b/deploy/helm/o11y-client/README.md
@@ -1,0 +1,10 @@
+# Observability client
+
+This helm chart installs the following components:
+
+- `victoria-metrics-operator`: An operator for managing [Victoria Metrics][victoria-metrics] deployments.
+- `victoria-metrics-agent`: An agent that scrapes metrics and sends them to a [Victoria Metrics][victoria-metrics] instance.
+- `kube-state-metrics`: A service that listens to the Kubernetes API server and generates metrics about the state of the objects.
+- `prometheus-node-exporter`: A service that collects metrics about the node it runs on.
+
+[victoria-metrics]: https://victoriametrics.com/

--- a/deploy/helm/o11y-client/values.yaml
+++ b/deploy/helm/o11y-client/values.yaml
@@ -1,0 +1,31 @@
+# TODO: How to deal with CRD updates?
+
+victoria-metrics-k8s-stack:
+  enabled: true
+
+  victoria-metrics-operator:
+    enabled: true
+  operator:
+    enable_converter_ownership: true
+
+  vmsingle:
+    enabled: false
+
+  vmagent:
+    enabled: true
+    additionalRemoteWrites:
+      - url: "http://victoria-metrics.10.0.11.33.nip.io/api/v1/write"
+    spec:
+      externalLabels:
+        cluster: "yak"
+
+  # TODO: Configure alerting.
+  alertmanager:
+    enabled: false
+
+  vmalert:
+    enabled: false
+
+  # This is part of the `o11y-ui` chart.
+  grafana:
+    enabled: false

--- a/deploy/helm/o11y-server/Chart.yaml
+++ b/deploy/helm/o11y-server/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: o11y-server
+description: The server-side component of an observability platform.
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+dependencies:
+  - name: victoria-metrics-single
+    version: 0.9.16
+    repository: https://victoriametrics.github.io/helm-charts/
+    condition: victoria-metrics-single.enabled

--- a/deploy/helm/o11y-server/README.md
+++ b/deploy/helm/o11y-server/README.md
@@ -1,0 +1,7 @@
+# Observability server
+
+This helm chart installs the following components:
+
+- `victoria-metrics-single`: A single-node deployment of [Victoria Metrics][victoria-metrics].
+
+[victoria-metrics]: https://victoriametrics.com/

--- a/deploy/helm/o11y-server/values.yaml
+++ b/deploy/helm/o11y-server/values.yaml
@@ -1,0 +1,11 @@
+# TODO: Set up authentication.
+
+victoria-metrics-single:
+  enabled: true
+  server:
+    ingress:
+      enabled: true
+      hosts:
+        - name: "victoria-metrics.10.0.11.33.nip.io"
+          path: "/"
+          port: http

--- a/deploy/helm/o11y-ui/Chart.yaml
+++ b/deploy/helm/o11y-ui/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: o11y-ui
+description: The UI for an observability platform.
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+dependencies:
+  - name: grafana
+    version: 7.3.3
+    repository: https://grafana.github.io/helm-charts
+    condition: grafana.enabled

--- a/deploy/helm/o11y-ui/README.md
+++ b/deploy/helm/o11y-ui/README.md
@@ -1,0 +1,5 @@
+# Observability UI
+
+This helm chart installs the following components:
+
+- `grafana`: A single pane of glass for metrics, logs, and traces.

--- a/deploy/helm/o11y-ui/values.yaml
+++ b/deploy/helm/o11y-ui/values.yaml
@@ -1,0 +1,24 @@
+grafana:
+  enabled: true
+  ingress:
+    enabled: true
+    hosts:
+      - grafana.10.0.11.33.nip.io
+  persistence:
+    enabled: true
+  resources:
+    requests:
+      cpu: 200m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Victoria Metrics
+          type: prometheus
+          url: http://victoria-metrics.10.0.11.33.nip.io
+          access: proxy
+          isDefault: true

--- a/deploy/helm/traefik/values.new.yaml
+++ b/deploy/helm/traefik/values.new.yaml
@@ -1,0 +1,42 @@
+ingressClass:
+  enabled: yes
+  isDefaultClass: yes
+
+service:
+  enabled: yes
+  type: LoadBalancer
+  single: false
+
+resources:
+  requests:
+    cpu: 128m
+    memory: 256Mi
+  limits:
+    cpu: 128m
+    memory: 256Mi
+
+ports:
+  traefik:
+    port: 9000
+    expose: no
+    exposedPort: 9000
+    protocol: TCP
+  web:
+    port: 8080
+    expose: yes
+    exposedPort: 80
+    nodePort: 30080
+    protocol: TCP
+  websecure:
+    port: 8443
+    expose: yes
+    exposedPort: 443
+    nodePort: 30443
+    protocol: TCP
+    tls:
+      enabled: yes
+
+providers:
+  kubernetesIngress:
+    publishedService:
+      enabled: true


### PR DESCRIPTION
This creates a simple centralized monitoring stack consisting of 3 components:
- `o11y-client`: Collects metrics and logs and send them to a centralized observability stack
- `o11y-server`: Provides API for metrics and log ingestion
- `o11y-ui`: Provides a single pane of glass for metrics and logs